### PR TITLE
Add MongoDB project API and realtime projects page

### DIFF
--- a/my-portfolio/README.md
+++ b/my-portfolio/README.md
@@ -1,36 +1,33 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Portfolio
 
-## Getting Started
+A simple portfolio built with Next.js (App Router), TypeScript and Tailwind CSS.
 
-First, run the development server:
+## Features
+
+- API routes using Next.js Route Handlers
+- MongoDB database using the official driver
+- Zod schemas for input validation
+- Real-time updates via MongoDB Change Streams and Server-Sent Events
+
+## Development
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Provide environment variables:
+
+```
+MONGODB_URI=your-mongo-uri
+MONGODB_DB=portfolio
+```
+
+3. Run the dev server
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Projects can be added by sending `POST /api/projects` with `{ "title": "...", "description": "..." }` and will appear on the `/projects` page in real time.

--- a/my-portfolio/package.json
+++ b/my-portfolio/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.5.2"
+    "next": "15.5.2",
+    "mongodb": "^6.0.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/my-portfolio/src/app/api/projects/route.ts
+++ b/my-portfolio/src/app/api/projects/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getCollection } from "@/lib/mongodb";
+
+const projectSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().min(1),
+});
+
+export async function GET() {
+  const collection = await getCollection("projects");
+  const projects = await collection.find().sort({ _id: -1 }).toArray();
+  return NextResponse.json(projects);
+}
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const parsed = projectSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+  const collection = await getCollection("projects");
+  const { insertedId } = await collection.insertOne(parsed.data);
+  return NextResponse.json({ _id: insertedId, ...parsed.data }, { status: 201 });
+}

--- a/my-portfolio/src/app/api/projects/stream/route.ts
+++ b/my-portfolio/src/app/api/projects/stream/route.ts
@@ -1,0 +1,32 @@
+import { getClient } from "@/lib/mongodb";
+
+export async function GET() {
+  const client = getClient();
+  await client.connect();
+  const changeStream = client
+    .db(process.env.MONGODB_DB || "portfolio")
+    .collection("projects")
+    .watch([], { fullDocument: "updateLookup" });
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      changeStream.on("change", (change) => {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(change.fullDocument)}\n\n`)
+        );
+      });
+    },
+    cancel() {
+      changeStream.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/my-portfolio/src/app/page.tsx
+++ b/my-portfolio/src/app/page.tsx
@@ -1,103 +1,12 @@
-import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <main className="min-h-screen flex flex-col items-center justify-center space-y-4">
+      <h1 className="text-3xl font-bold">Welcome to my portfolio</h1>
+      <Link href="/projects" className="text-blue-600 hover:underline">
+        View Projects
+      </Link>
+    </main>
   );
 }

--- a/my-portfolio/src/app/projects/page.tsx
+++ b/my-portfolio/src/app/projects/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Project {
+  _id: string;
+  title: string;
+  description: string;
+}
+
+export default function ProjectsPage() {
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    fetch("/api/projects")
+      .then((res) => res.json())
+      .then((data) => setProjects(data));
+
+    const evtSource = new EventSource("/api/projects/stream");
+    evtSource.onmessage = (e) => {
+      const project: Project = JSON.parse(e.data);
+      setProjects((prev) => [project, ...prev]);
+    };
+    return () => evtSource.close();
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Projects</h1>
+      <ul className="space-y-4">
+        {projects.map((p) => (
+          <li key={p._id} className="border p-4 rounded">
+            <h2 className="font-semibold">{p.title}</h2>
+            <p>{p.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/my-portfolio/src/lib/mongodb.ts
+++ b/my-portfolio/src/lib/mongodb.ts
@@ -1,0 +1,17 @@
+import { MongoClient } from "mongodb";
+
+const uri = process.env.MONGODB_URI || "mongodb://localhost:27017";
+const dbName = process.env.MONGODB_DB || "portfolio";
+
+const client = new MongoClient(uri);
+
+export async function getCollection(name: string) {
+  if (!client.topology) {
+    await client.connect();
+  }
+  return client.db(dbName).collection(name);
+}
+
+export function getClient() {
+  return client;
+}


### PR DESCRIPTION
## Summary
- set up MongoDB connection helper and Zod-validated project API
- add SSE stream endpoint and realtime projects page
- simplify homepage and document stack

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: eslint: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b4975e4930832c8ef7f99f8709eac4