### PR TITLE
Handle empty responses when fetching projects

### DIFF
--- a/my-portfolio/src/app/projects/page.tsx
+++ b/my-portfolio/src/app/projects/page.tsx
@@ -12,9 +12,23 @@ export default function ProjectsPage() {
   const [projects, setProjects] = useState<Project[]>([]);
 
   useEffect(() => {
-    fetch("/api/projects")
-      .then((res) => res.json())
-      .then((data) => setProjects(data));
+    async function loadProjects() {
+      try {
+        const res = await fetch("/api/projects");
+        if (!res.ok) {
+          console.error("Failed to fetch projects", res.statusText);
+          return;
+        }
+
+        const text = await res.text();
+        const data: Project[] = text ? JSON.parse(text) : [];
+        setProjects(data);
+      } catch (err) {
+        console.error("Error loading projects", err);
+      }
+    }
+
+    loadProjects();
 
     const evtSource = new EventSource("/api/projects/stream");
     evtSource.onmessage = (e) => {


### PR DESCRIPTION
## Summary
- ensure projects page handles non-OK or empty responses
- log errors when fetching fails instead of crashing on json parse

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/eslintrc')

------
https://chatgpt.com/codex/tasks/task_e_68b49c5c8d58832cb9621fde3c2feeb9