### PR TITLE
Handle project API errors gracefully

### DIFF
--- a/my-portfolio/src/app/api/projects/route.ts
+++ b/my-portfolio/src/app/api/projects/route.ts
@@ -8,21 +8,34 @@ const projectSchema = z.object({
 });
 
 export async function GET() {
-  const collection = await getCollection("projects");
-  const projects = await collection.find().sort({ _id: -1 }).toArray();
-  return NextResponse.json(projects);
+  try {
+    const collection = await getCollection("projects");
+    const projects = await collection.find().sort({ _id: -1 }).toArray();
+    return NextResponse.json(projects);
+  } catch (err) {
+    console.error("Error fetching projects", err);
+    return NextResponse.json([]);
+  }
 }
 
 export async function POST(request: Request) {
-  const body = await request.json();
-  const parsed = projectSchema.safeParse(body);
-  if (!parsed.success) {
+  try {
+    const body = await request.json();
+    const parsed = projectSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+    const collection = await getCollection("projects");
+    const { insertedId } = await collection.insertOne(parsed.data);
+    return NextResponse.json({ _id: insertedId, ...parsed.data }, { status: 201 });
+  } catch (err) {
+    console.error("Error creating project", err);
     return NextResponse.json(
-      { error: parsed.error.flatten().fieldErrors },
-      { status: 400 }
+      { error: "Failed to create project" },
+      { status: 500 }
     );
   }
-  const collection = await getCollection("projects");
-  const { insertedId } = await collection.insertOne(parsed.data);
-  return NextResponse.json({ _id: insertedId, ...parsed.data }, { status: 201 });
 }


### PR DESCRIPTION
## Summary
- avoid server crash when fetching projects by catching database errors
- return informative errors from project creation endpoint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b49d49af14832cbea132d1ce645840