### PR TITLE
Fix sidebar clipping in projects section

### DIFF
--- a/my-portfolio/src/app/page.tsx
+++ b/my-portfolio/src/app/page.tsx
@@ -83,7 +83,7 @@ export default function Home() {
   ];
 
   return (
-    <main className="min-h-screen relative overflow-hidden">
+    <main className="min-h-screen relative overflow-x-hidden">
 
       {/* Content */}
       <div className="relative z-10">


### PR DESCRIPTION
## Summary
- switch the main layout container to only hide horizontal overflow so that the decorative sidebars can move with the page

## Testing
- npm run lint *(fails: Cannot find package '/workspace/portfolio/my-portfolio/node_modules/@eslint/eslintrc/index.js' imported from /workspace/portfolio/my-portfolio/eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0821ead0832ca730154035f6dfe1